### PR TITLE
chore: bump to 0.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,7 +403,7 @@ checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "limlog"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "arc-swap",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "limlog"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
This version adds graceful shutdown and smallvec support.